### PR TITLE
Update the URLs for the QuIC Submission

### DIFF
--- a/closed/Qualcomm/code/mobilenet/reference/VERSION.txt
+++ b/closed/Qualcomm/code/mobilenet/reference/VERSION.txt
@@ -1,2 +1,2 @@
-git clone https://source.codeaurora.org/quic/mlperfqc/snpe-mlperf-net-run
+git clone https://git.codelinaro.org/clo/mlperfqc/snpe-mlperf-net-run.git
 e96a2f2bbfc0dd28267608c9e6063845b1ca9d3e

--- a/closed/Qualcomm/code/resnet/reference/VERSION.txt
+++ b/closed/Qualcomm/code/resnet/reference/VERSION.txt
@@ -1,2 +1,2 @@
-git clone https://source.codeaurora.org/quic/mlperfqc/snpe-mlperf-net-run
+git clone https://git.codelinaro.org/clo/mlperfqc/snpe-mlperf-net-run.git
 e96a2f2bbfc0dd28267608c9e6063845b1ca9d3e

--- a/open/Qualcomm/code/mobilenet/reference/VERSION.txt
+++ b/open/Qualcomm/code/mobilenet/reference/VERSION.txt
@@ -1,2 +1,2 @@
-git clone https://source.codeaurora.org/quic/mlperfqc/snpe-mlperf-net-run
+git clone https://git.codelinaro.org/clo/mlperfqc/snpe-mlperf-net-run.git
 e96a2f2bbfc0dd28267608c9e6063845b1ca9d3e


### PR DESCRIPTION
Qualcomm Innovation Center submission references code that was
moved to a new repository. The git hashes remain the same.
Updating the location of the repo.